### PR TITLE
Properly convert backslashed character

### DIFF
--- a/phplib/AdminStringUtil.php
+++ b/phplib/AdminStringUtil.php
@@ -470,7 +470,7 @@ class AdminStringUtil {
   }
 
   private static function _ordReplace($matches) {
-    return '&#x' . dechex(self::ord($matches[0])) . ';';
+    return '&#x' . dechex(self::ord($matches[1])) . ';';
   }
 
   static function xmlizeRequired($s) {


### PR DESCRIPTION
Convert the matched character (`$matches[1]`) instead of the entire match (`$matches[0]`, which includes the backslashes) to hex when exporting to XML. This should fix a bug where definition text such as `HOGAȘ, M\\. N\\.` gets dumped to XML as `HOGAȘ, M&#x5c; N&#x5c;`. `&#x5c;` is backslash, so the previous string translates to `HOGAȘ, M\ N\`.